### PR TITLE
Job file list is fetched when needed

### DIFF
--- a/app/controllers/api/files_controller.rb
+++ b/app/controllers/api/files_controller.rb
@@ -1,0 +1,16 @@
+class Api::FilesController < Api::ApiController
+  before_filter -> { validate_rights 'manage_jobs' }
+
+  api!
+  def index
+    job_id = params[:job_id]
+    job = Job.find_by_id(job_id)
+    if job.nil?
+      error_msg(ErrorCodes::OBJECT_ERROR, "Could not find job '#{params[:job_id]}'")
+      render_json
+      return false
+    end
+    @response[:files] = job.files_list
+    render_json
+  end
+end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -77,7 +77,6 @@ class Job < ActiveRecord::Base
         source_link: source_link,
         package_metadata: package_metadata_hash,
         main_status: main_status,
-        files: files_list,
         is_periodical: is_periodical,
         status: flow_step ? flow_step.description : "",
         flow_step: flow_step,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
     get 'statistics/:id', to: 'statistics#get_build_status'
     get 'statistics/download/:id', to: 'statistics#download'
 
+    get 'files', to: 'files#index'
   end
   mount_ember_app :frontend, to: "/"
 end

--- a/frontend/app/adapters/dflow.js
+++ b/frontend/app/adapters/dflow.js
@@ -8,6 +8,7 @@ export default Ember.Object.extend({
     config: { path: 'api/config'},
     source: { path: 'api/sources'},
     job: { path: 'api/jobs'},
+    file: { path: 'api/files'},
     process: { path: 'api/process', singular: 'job'},
     flow: { path: 'api/flows'},
     thumbnail: {path: 'assets/thumbnail'},

--- a/frontend/app/controllers/jobs/show.js
+++ b/frontend/app/controllers/jobs/show.js
@@ -58,6 +58,16 @@ export default Ember.Controller.extend({
     },
     setOpen(string) {
       this.set('open', string);
+      if (string === 'files') {
+        if (!this.get('files')) {
+          let job_id = this.get('model.id');
+          this.store.find('file', {job_id: job_id}).then(
+            (files) => {
+              this.set('files', files);
+            }
+          );
+        }
+      }
     }
   }
   

--- a/frontend/app/routes/jobs/show.js
+++ b/frontend/app/routes/jobs/show.js
@@ -22,6 +22,7 @@ export default Ember.Route.extend({
       controller.set('newFlowStep', model.current_flow_step);
     });
     controller.set('model', job_model);
+    controller.set('files', null);
   },
   actions: {
     

--- a/frontend/app/templates/jobs/show.hbs
+++ b/frontend/app/templates/jobs/show.hbs
@@ -287,7 +287,7 @@
           <div id="collapseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree">
             <div class="panel-body">
               {{#if filesIsOpen}}
-              {{#each model.files as |file|}}
+              {{#each files as |file|}}
               {{tree-item item=file jobId=model.id}}
               {{/each}}
               {{/if}}


### PR DESCRIPTION
DFLOW-226: To avoid long wait for a job to load, job file list is fetched when the user explicitly wants to show it.