### PR TITLE
Remove error message when leaving page

### DIFF
--- a/frontend/app/routes/application.js
+++ b/frontend/app/routes/application.js
@@ -130,6 +130,9 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
     },
     refreshApplication: function(){
       this.refresh();
+    },
+    willTransition: function() {
+      this.controller.set('job_id_error', null);
     }
   }
 });


### PR DESCRIPTION
DFLOW-335: Error message in the menue when a job is not found will disappear when leaving page