### PR TITLE
Increase foolproofness of production deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,3 +26,15 @@ set :default_env, {
 }
 
 set :branch, 'master'
+
+namespace :deploy do
+  before "git:check", :alert_deploying_to_stage do
+    on roles(:all) do |host|
+      colors = SSHKit::Color.new($stdout)
+      message = "You are about to deploy to #{fetch(:stage)}"
+      if fetch(:stage) == :production
+        info colors.colorize("\e[5m#{message}!\e[0m", :red)
+      end
+    end
+  end
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,0 +1,1 @@
+set :branch, ''


### PR DESCRIPTION
Make production warning stand out more with annoying
blinking text and force user inputting branch to deploy